### PR TITLE
Network [#78] 기존 단체 입장 초대코드 화면 네트워크 구현

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS.xcodeproj/project.pbxproj
+++ b/PINGLE-iOS/PINGLE-iOS.xcodeproj/project.pbxproj
@@ -109,6 +109,9 @@
 		F1239BD52B47D5530072A02A /* EnterInviteCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1239BD42B47D5530072A02A /* EnterInviteCodeViewController.swift */; };
 		F1239BD72B47D8F60072A02A /* OrganizationInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1239BD62B47D8F60072A02A /* OrganizationInfoView.swift */; };
 		F1239BD92B486B230072A02A /* EntranceCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1239BD82B486B230072A02A /* EntranceCompletedViewController.swift */; };
+		F125A1842B4FC6A500739C34 /* EnterInviteCodeRequestBodyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125A1832B4FC6A500739C34 /* EnterInviteCodeRequestBodyDTO.swift */; };
+		F125A1862B4FC77800739C34 /* OrganizationDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125A1852B4FC77800739C34 /* OrganizationDetailResponseDTO.swift */; };
+		F125A1882B4FC82600739C34 /* EnterInviteCodeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125A1872B4FC82600739C34 /* EnterInviteCodeResponseDTO.swift */; };
 		F14F3C652B4945E00049A9EE /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14F3C642B4945E00049A9EE /* SettingViewController.swift */; };
 		F14F3C692B494FB10049A9EE /* OrganizationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14F3C682B494FB10049A9EE /* OrganizationButton.swift */; };
 		F14F3C6B2B4981110049A9EE /* SettingSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14F3C6A2B4981110049A9EE /* SettingSelectButton.swift */; };
@@ -228,6 +231,9 @@
 		F1239BD42B47D5530072A02A /* EnterInviteCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterInviteCodeViewController.swift; sourceTree = "<group>"; };
 		F1239BD62B47D8F60072A02A /* OrganizationInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationInfoView.swift; sourceTree = "<group>"; };
 		F1239BD82B486B230072A02A /* EntranceCompletedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntranceCompletedViewController.swift; sourceTree = "<group>"; };
+		F125A1832B4FC6A500739C34 /* EnterInviteCodeRequestBodyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterInviteCodeRequestBodyDTO.swift; sourceTree = "<group>"; };
+		F125A1852B4FC77800739C34 /* OrganizationDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationDetailResponseDTO.swift; sourceTree = "<group>"; };
+		F125A1872B4FC82600739C34 /* EnterInviteCodeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterInviteCodeResponseDTO.swift; sourceTree = "<group>"; };
 		F14F3C642B4945E00049A9EE /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		F14F3C682B494FB10049A9EE /* OrganizationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationButton.swift; sourceTree = "<group>"; };
 		F14F3C6A2B4981110049A9EE /* SettingSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSelectButton.swift; sourceTree = "<group>"; };
@@ -822,6 +828,7 @@
 			children = (
 				F14F3C732B4D36BB0049A9EE /* LoginRequestBodyDTO.swift */,
 				F1A186182B4FB2CE0000BCF3 /* SearchOrganizationRequestQueryDTO.swift */,
+				F125A1832B4FC6A500739C34 /* EnterInviteCodeRequestBodyDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -832,6 +839,8 @@
 				F14F3C762B4D37080049A9EE /* LoginResponseDTO.swift */,
 				F111BE652B4E8606001D116C /* UserInfoResponseDTO.swift */,
 				F1A186162B4FB0D10000BCF3 /* SearchOrganizationResponseDTO.swift */,
+				F125A1852B4FC77800739C34 /* OrganizationDetailResponseDTO.swift */,
+				F125A1872B4FC82600739C34 /* EnterInviteCodeResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1007,6 +1016,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F14F3C702B49BEB60049A9EE /* AccountPopUpView.swift in Sources */,
+				F125A1882B4FC82600739C34 /* EnterInviteCodeResponseDTO.swift in Sources */,
 				C30C91882B4CEBD7004EE026 /* HTTPHeaderFieldKey.swift in Sources */,
 				C396031E2B3BF379004BB2B8 /* s.swift in Sources */,
 				F14F3C772B4D37080049A9EE /* LoginResponseDTO.swift in Sources */,
@@ -1065,6 +1075,7 @@
 				C30728192B414FC800AA575B /* UIStackView+.swift in Sources */,
 				F1239BD32B4724900072A02A /* PINGLEWarningToastView.swift in Sources */,
 				F1239BBF2B4557810072A02A /* SearchOrganizationViewController.swift in Sources */,
+				F125A1862B4FC77800739C34 /* OrganizationDetailResponseDTO.swift in Sources */,
 				C39602DB2B3BF199004BB2B8 /* Color.swift in Sources */,
 				F111BE682B4E8CEB001D116C /* NetworkManager.swift in Sources */,
 				C39B8D222B4CFB68008DCAC6 /* HomeTarget.swift in Sources */,
@@ -1091,6 +1102,7 @@
 				E5A651E82B4973AB00676ED0 /* DateSelectionViewController.swift in Sources */,
 				F1239BCF2B468A0F0072A02A /* CALayer+.swift in Sources */,
 				E5A651FC2B4B834900676ED0 /* InsertOpenChatLinkViewController.swift in Sources */,
+				F125A1842B4FC6A500739C34 /* EnterInviteCodeRequestBodyDTO.swift in Sources */,
 				F1239BCB2B45D5CD0072A02A /* BasePaddingLabel.swift in Sources */,
 				C38545402B4868860040E60D /* String+.swift in Sources */,
 				E5A651FA2B4B2A6F00676ED0 /* RecruitButton.swift in Sources */,

--- a/PINGLE-iOS/PINGLE-iOS/Network/Base/HTTPHeaderFieldKey.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Base/HTTPHeaderFieldKey.swift
@@ -13,7 +13,7 @@ enum HTTPHeaderFieldKey: String {
     case acceptType = "Accept"
     case accessToken = "accessToken"
     case refreshtoken = "refreshtoken"
-    case providerToken = "Provider-Token"
+    case providerToken = "X-Provider-Token"
     case xAccessAuth = "X-ACCESS-AUTH"
     case xRefreshAuth = "X-REFRESH-AUTH"
 }

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/DTO/Request/EnterInviteCodeRequestBodyDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/DTO/Request/EnterInviteCodeRequestBodyDTO.swift
@@ -1,0 +1,12 @@
+//
+//  EnterInviteCodeBodyDTO.swift
+//  PINGLE-iOS
+//
+//  Created by 강민수 on 1/11/24.
+//
+
+import Foundation
+
+struct EnterInviteCodeRequestBodyDTO: Codable {
+    let code: String
+}

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/DTO/Request/EnterInviteCodeRequestBodyDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/DTO/Request/EnterInviteCodeRequestBodyDTO.swift
@@ -1,5 +1,5 @@
 //
-//  EnterInviteCodeBodyDTO.swift
+//  EnterInviteCodeRequestBodyDTO.swift
 //  PINGLE-iOS
 //
 //  Created by 강민수 on 1/11/24.

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/EnterInviteCodeResponseDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/EnterInviteCodeResponseDTO.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+struct EnterInviteCodeResponseDTO: Codable {
+    let id: Int
+    let name: String
+}

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/EnterInviteCodeResponseDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/EnterInviteCodeResponseDTO.swift
@@ -1,0 +1,8 @@
+//
+//  EnterInviteCodeResponseDTO.swift
+//  PINGLE-iOS
+//
+//  Created by 강민수 on 1/11/24.
+//
+
+import Foundation

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/OrganizationDetailResponseDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/OrganizationDetailResponseDTO.swift
@@ -1,8 +1,16 @@
 //
-//  OrganizationResponseDTO.swift
+//  OrganizationDetailResponseDTO.swift
 //  PINGLE-iOS
 //
 //  Created by 강민수 on 1/11/24.
 //
 
 import Foundation
+
+struct OrganizationDetailResponseDTO: Codable {
+    let id: Int
+    let keyword: String
+    let name: String
+    let meetingCount: Int
+    let participantCount: Int
+}

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/OrganizationDetailResponseDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/OrganizationDetailResponseDTO.swift
@@ -1,0 +1,8 @@
+//
+//  OrganizationResponseDTO.swift
+//  PINGLE-iOS
+//
+//  Created by 강민수 on 1/11/24.
+//
+
+import Foundation

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -13,6 +13,8 @@ enum OnboardingTarget {
     case login(_ bodyDTO: LoginRequestBodyDTO)
     case userInfo
     case searchOrganization(_ queryDTO: SearchOrganizationRequestQueryDTO)
+    case organizationDetail(_ teamId: Int)
+    case enterInviteCode(_ teamId: Int, bodyDTO: EnterInviteCodeRequestBodyDTO)
 }
 
 extension OnboardingTarget: TargetType {
@@ -23,6 +25,10 @@ extension OnboardingTarget: TargetType {
         case .userInfo:
             return .authorization
         case .searchOrganization:
+            return .authorization
+        case .organizationDetail:
+            return .authorization
+        case .enterInviteCode:
             return .authorization
         }
     }
@@ -35,6 +41,10 @@ extension OnboardingTarget: TargetType {
             return .hasToken
         case .searchOrganization:
             return .hasToken
+        case .organizationDetail:
+            return .hasToken
+        case .enterInviteCode:
+            return .hasToken
         }
     }
     
@@ -46,6 +56,10 @@ extension OnboardingTarget: TargetType {
             return .get
         case .searchOrganization:
             return .get
+        case .organizationDetail:
+            return .get
+        case .enterInviteCode:
+            return .post
         }
     }
     
@@ -57,6 +71,10 @@ extension OnboardingTarget: TargetType {
             return "/users/me"
         case .searchOrganization:
             return "/teams"
+        case .organizationDetail(let teamId):
+            return "/teams/\(teamId)"
+        case .enterInviteCode(let teamId, _):
+            return "/teams/\(teamId)/register"
         }
     }
     
@@ -68,6 +86,10 @@ extension OnboardingTarget: TargetType {
             return .requestPlain
         case .searchOrganization(let queryDTO):
             return .requestQuery(queryDTO)
+        case .organizationDetail:
+            return .requestPlain
+        case .enterInviteCode(_, let bodyDTO):
+            return .requestWithBody(bodyDTO)
         }
     }
 }

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Router/OnboardingTarget.swift
@@ -14,7 +14,7 @@ enum OnboardingTarget {
     case userInfo
     case searchOrganization(_ queryDTO: SearchOrganizationRequestQueryDTO)
     case organizationDetail(_ teamId: Int)
-    case enterInviteCode(_ teamId: Int, bodyDTO: EnterInviteCodeRequestBodyDTO)
+    case enterInviteCode(_ teamId: Int, _ bodyDTO: EnterInviteCodeRequestBodyDTO)
 }
 
 extension OnboardingTarget: TargetType {

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Service/OnboardingService.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Service/OnboardingService.swift
@@ -34,7 +34,7 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
     }
     
     func enterInviteCode(teamId: Int, bodyDTO: EnterInviteCodeRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EnterInviteCodeResponseDTO>>) -> Void) {
-        fetchData(target: .organizationDetail(teamId),
+        fetchData(target: .enterInviteCode(teamId, bodyDTO),
                   responseData: BaseResponse<EnterInviteCodeResponseDTO>.self, completion: completion)
     }
 }

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Service/OnboardingService.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Service/OnboardingService.swift
@@ -11,6 +11,8 @@ protocol OnboardingServiceProtocol {
     func login(bodyDTO: LoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<LoginResponseDTO>>) -> Void)
     func userInfo(completion: @escaping (NetworkResult<BaseResponse<UserInfoResponseDTO>>) -> Void)
     func searchOrganization(queryDTO: SearchOrganizationRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<[SearchOrganizationResponseDTO]>>) -> Void)
+    func organizationDetail(teamId: Int, completion: @escaping (NetworkResult<BaseResponse<OrganizationDetailResponseDTO>>) -> Void)
+    func enterInviteCode(teamId: Int, bodyDTO: EnterInviteCodeRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EnterInviteCodeResponseDTO>>) -> Void)
 }
 
 final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingServiceProtocol {
@@ -25,5 +27,14 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
     func searchOrganization(queryDTO: SearchOrganizationRequestQueryDTO, completion: @escaping (NetworkResult<BaseResponse<[SearchOrganizationResponseDTO]>>) -> Void) {
         fetchData(target: .searchOrganization(queryDTO),
                   responseData: BaseResponse<[SearchOrganizationResponseDTO]>.self, completion: completion)
+    }
+    func organizationDetail(teamId: Int, completion: @escaping (NetworkResult<BaseResponse<OrganizationDetailResponseDTO>>) -> Void) {
+        fetchData(target: .organizationDetail(teamId),
+                  responseData: BaseResponse<OrganizationDetailResponseDTO>.self, completion: completion)
+    }
+    
+    func enterInviteCode(teamId: Int, bodyDTO: EnterInviteCodeRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EnterInviteCodeResponseDTO>>) -> Void) {
+        fetchData(target: .organizationDetail(teamId),
+                  responseData: BaseResponse<EnterInviteCodeResponseDTO>.self, completion: completion)
     }
 }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/Cell/SearchCollectionViewCell.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/Cell/SearchCollectionViewCell.swift
@@ -43,7 +43,6 @@ final class SearchCollectionViewCell: UICollectionViewCell {
         }
         
         self.keywordLabel.do {
-            $0.text = "통신 키워드"
             $0.font = .captionCapSemi10
             $0.textColor = .mainPingleGreen
             $0.layer.backgroundColor = UIColor.grayscaleG10.cgColor
@@ -51,7 +50,6 @@ final class SearchCollectionViewCell: UICollectionViewCell {
         }
         
         self.groupNameLabel.do {
-            $0.text = "단체 이름"
             $0.font = .bodyBodyMed16
             $0.textColor = .white
         }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/OrganizationInfoView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/OrganizationInfoView.swift
@@ -32,7 +32,6 @@ final class OrganizationInfoView: BaseView {
         }
         
         self.keywordLabel.do {
-            $0.text = "통신키워드"
             $0.font = .captionCapSemi12
             $0.textColor = .mainPingleGreen
             $0.layer.backgroundColor = UIColor.grayscaleG10.cgColor
@@ -40,7 +39,6 @@ final class OrganizationInfoView: BaseView {
         }
         
         self.organizationNameLabel.do {
-            $0.text = "HTTP"
             $0.font = .titleTitleSemi24
             $0.textColor = .black
         }
@@ -52,7 +50,6 @@ final class OrganizationInfoView: BaseView {
         }
         
         self.meetingNumberLabel.do {
-            $0.text = "n개"
             $0.font = .bodyBodyMed14
             $0.textColor = .grayscaleG08
         }
@@ -64,7 +61,6 @@ final class OrganizationInfoView: BaseView {
         }
         
         self.memberNumberLabel.do {
-            $0.text = "n명"
             $0.font = .bodyBodyMed14
             $0.textColor = .grayscaleG08
         }
@@ -104,5 +100,12 @@ final class OrganizationInfoView: BaseView {
             $0.leading.equalTo(meetingNumberLabel)
             $0.centerY.equalTo(memberNumberTitleLabel)
         }
+    }
+    
+    func bindData(data: OrganizationDetailResponseDTO) {
+        keywordLabel.text = data.keyword
+        organizationNameLabel.text = data.name
+        meetingNumberLabel.text = "\(data.meetingCount)개"
+        memberNumberLabel.text = "\(data.participantCount)명"
     }
 }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift
@@ -25,6 +25,7 @@ final class EnterInviteCodeViewController: BaseViewController {
     private let infoMessageLabel = UILabel()
     private let bottomCTAButton = PINGLECTAButton(title: StringLiterals.CTAButton.enterTitle, buttonColor: .grayscaleG08, textColor: .grayscaleG10)
     private let warningToastView = PINGLEWarningToastView(warningLabel: StringLiterals.ToastView.wrongCode)
+    var teamId: Int?
     
     // MARK: Life Cycle
     override func viewWillAppear(_ animated: Bool) {
@@ -34,6 +35,7 @@ final class EnterInviteCodeViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        getOrganizationDetail()
         setNavigation()
         setTarget()
         setupKeyboardEvent()
@@ -52,6 +54,10 @@ final class EnterInviteCodeViewController: BaseViewController {
         
         self.titleBackgroundView.do {
             $0.backgroundColor = .grayscaleG11
+        }
+        
+        self.organizationInfoView.do {
+            $0.isHidden = true
         }
         
         self.titleLabel.do {
@@ -174,6 +180,22 @@ final class EnterInviteCodeViewController: BaseViewController {
                                                selector: #selector(keyboardWillHide),
                                                name: UIResponder.keyboardWillHideNotification,
                                                object: nil)
+    }
+    
+    // MARK: Network Function
+    func getOrganizationDetail() {
+        guard let teamId = teamId else { return }
+        NetworkService.shared.onboardingService.organizationDetail(teamId: teamId) { [weak self] response in
+            guard let self = self else { return }
+            switch response {
+            case .success(let data):
+                guard let data = data.data else { return }
+                organizationInfoView.bindData(data: data)
+                organizationInfoView.isHidden = false
+            default:
+                print("login error")
+            }
+        }
     }
 }
 

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
@@ -117,6 +117,9 @@ final class EntranceCompletedViewController: BaseViewController {
     
     // MARK: Objc Function
     @objc func bottomCTAButtonTapped() {
+        let PINGLETabBarController = PINGLETabBarController()
+        self.view.window?.rootViewController = PINGLETabBarController
+        self.view.window?.makeKeyAndVisible()
     }
     
     // MARK: SetButton

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
@@ -112,7 +112,7 @@ final class LoginViewController: BaseViewController {
     @objc func handleAuthorizationAppleIDButtonPress() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName]
+        request.requestedScopes = [.fullName, .email]
         
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
@@ -155,6 +155,9 @@ final class SearchOrganizationViewController: BaseViewController {
                 searchOrganization(data: SearchOrganizationRequestQueryDTO(name: searchText))
             }
         }
+        /// 선택된 행 해제한 뒤, 다음으로 버튼 비활성화
+        selectedCellIndex = nil
+        bottomCTAButton.disabledButton()
         self.view.endEditing(true)
     }
     
@@ -165,7 +168,9 @@ final class SearchOrganizationViewController: BaseViewController {
     }
     
     @objc func bottomCTAButtonTapped() {
+        guard let selectedCellIndowRow = selectedCellIndex?.row else { return }
         let enterInviteCodeViewController = EnterInviteCodeViewController()
+        enterInviteCodeViewController.teamId = searchOrganizationResponseDTO[selectedCellIndowRow].id
         navigationController?.pushViewController(enterInviteCodeViewController, animated: true)
     }
     
@@ -206,6 +211,9 @@ extension SearchOrganizationViewController: UITextFieldDelegate {
                 searchOrganization(data: SearchOrganizationRequestQueryDTO(name: searchText))
             }
         }
+        /// 선택된 행 해제한 뒤, 다음으로 버튼 비활성화
+        selectedCellIndex = nil
+        bottomCTAButton.disabledButton()
         return true
     }
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 그룹 id와 그룹 명은 유저디폴트에 저장했습니다.
https://github.com/TeamPINGLE/PINGLE-iOS/blob/1ffff812cd19d4e90b3e8c951856422450f8674e/PINGLE-iOS/PINGLE-iOS/Network/Base/KeychainHandler.swift#L63-L70
해당 파일 참고해서 코드 작성하시면 될 것 같습니다.

서버에서 코드 400을 보내는 것도 서버와 통신이 되었다는 의미이므로 success로 갑니다. 따라서 초대코드가 실패했다는 것은 data.data에 빈 값을 보내기 때문에 if let문을 이용하여 경고 코드와 성공 코드를 나누었습니다. 또한, 이후에 여러 단체에 가입하는 경우가 있을 수 있으므로 유저디폴트에는 1개의 값을 갖고있는 리스트를 저장했습니다.
https://github.com/TeamPINGLE/PINGLE-iOS/blob/1ffff812cd19d4e90b3e8c951856422450f8674e/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift#L200-L221

단체 정보 값을 불러오는 과정에서 통신이 완료된 뒤 생성되면 어색해 보이기때문에 통신이 완료된 순간 단체 정보 뷰가 보이도록했습니다.
https://github.com/TeamPINGLE/PINGLE-iOS/blob/1ffff812cd19d4e90b3e8c951856422450f8674e/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift#L185-L198

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- 애플 로그인 시 이메일 추가했습니다.
- 애플 토큰 제목 변경했습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |  
| :-------------: | 
| ![초대코드통신구현2](https://github.com/TeamPINGLE/PINGLE-iOS/assets/62370742/e3aa5d4b-87d3-4ed1-a42f-4efb460bb17e) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #78 
