### PR TITLE
Fix [#107] 온보딩, 설정 플로우 QA 반영

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS.xcodeproj/project.pbxproj
+++ b/PINGLE-iOS/PINGLE-iOS.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		F14F44AB2B50411700871E5A /* ProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14F44AA2B50411700871E5A /* ProfileService.swift */; };
 		F14F44AD2B50413400871E5A /* ProfileTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14F44AC2B50413400871E5A /* ProfileTarget.swift */; };
 		F16BCA392B4E62760096A62F /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16BCA382B4E62760096A62F /* SplashViewController.swift */; };
+		F19CE2C02B5417C500B8F9D0 /* MyOrganizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19CE2BF2B5417C500B8F9D0 /* MyOrganizationViewController.swift */; };
 		F1A186172B4FB0D10000BCF3 /* SearchOrganizationResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A186162B4FB0D10000BCF3 /* SearchOrganizationResponseDTO.swift */; };
 		F1A186192B4FB2CE0000BCF3 /* SearchOrganizationRequestQueryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A186182B4FB2CE0000BCF3 /* SearchOrganizationRequestQueryDTO.swift */; };
 /* End PBXBuildFile section */
@@ -264,6 +265,7 @@
 		F14F44AA2B50411700871E5A /* ProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileService.swift; sourceTree = "<group>"; };
 		F14F44AC2B50413400871E5A /* ProfileTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTarget.swift; sourceTree = "<group>"; };
 		F16BCA382B4E62760096A62F /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
+		F19CE2BF2B5417C500B8F9D0 /* MyOrganizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyOrganizationViewController.swift; sourceTree = "<group>"; };
 		F1A186162B4FB0D10000BCF3 /* SearchOrganizationResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOrganizationResponseDTO.swift; sourceTree = "<group>"; };
 		F1A186182B4FB2CE0000BCF3 /* SearchOrganizationRequestQueryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOrganizationRequestQueryDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -895,6 +897,7 @@
 			isa = PBXGroup;
 			children = (
 				F14F3C642B4945E00049A9EE /* SettingViewController.swift */,
+				F19CE2BF2B5417C500B8F9D0 /* MyOrganizationViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1197,6 +1200,7 @@
 				C314F79D2B468F0B008EFFCA /* HomePinListResponseDTO.swift in Sources */,
 				F1A186192B4FB2CE0000BCF3 /* SearchOrganizationRequestQueryDTO.swift in Sources */,
 				C3E199EA2B4A3C01009B54B8 /* HomeListViewController.swift in Sources */,
+				F19CE2C02B5417C500B8F9D0 /* MyOrganizationViewController.swift in Sources */,
 				F14F3C652B4945E00049A9EE /* SettingViewController.swift in Sources */,
 				C30728192B414FC800AA575B /* UIStackView+.swift in Sources */,
 				F1239BD32B4724900072A02A /* PINGLEWarningToastView.swift in Sources */,

--- a/PINGLE-iOS/PINGLE-iOS/Application/NetworkManager.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Application/NetworkManager.swift
@@ -16,7 +16,9 @@ class NetworkManager {
             switch response {
             case .success(let data):
                 guard let data = data.data else { return }
-                KeychainHandler.shared.userGroup = data.groups
+                if let groups = data.groups {
+                    KeychainHandler.shared.userGroup = groups
+                }
                 resultCompletion(true)
             case .failure:
                 resultCompletion(false)

--- a/PINGLE-iOS/PINGLE-iOS/Application/SceneDelegate.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Application/SceneDelegate.swift
@@ -21,29 +21,30 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = splashViewController
         window.makeKeyAndVisible()
         
-        var rootViewController = UIViewController()
         let loginViewController = LoginViewController()
         let onboardingViewController = OnboardingViewController()
         let PINGLETabBarController = PINGLETabBarController()
         
-        /// 스플래쉬 화면이 시작
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
-            if KeychainHandler.shared.accessToken.isEmpty {
-                /// 어세스 토큰 없는 경우 - 애플 계정을 통한 회원가입을 한 적이 없는 경우
-                rootViewController = loginViewController
-            } else {
-                /// 어세스 토큰이 있는 경우 - 애플 계정을 통한 회원가입을 한 적이 있는 경우 : 가입한 단체가 있는지 확인하는 통신 코드 구현
-                networkManager.getUserInfo { [weak self] state in
-                    guard let self else { return }
-                    if KeychainHandler.shared.userGroup.isEmpty {
-                        /// 가입한 단체가 없는 경우 - 온보딩 화면에서 단체를 선택한 경험이 없는 경우
-                        rootViewController = onboardingViewController
-                    } else {
-                        /// 가입한 단체가 있는 경우 - 온보딩 화면에서 단체를 선택한 경험이 있는 경우
-                        rootViewController = PINGLETabBarController
-                    }
+        var rootViewController: UIViewController = loginViewController
+        
+        if KeychainHandler.shared.accessToken.isEmpty {
+            /// 어세스 토큰 없는 경우 - 애플 계정을 통한 회원가입을 한 적이 없는 경우
+            rootViewController = loginViewController
+        } else {
+            /// 어세스 토큰이 있는 경우 - 애플 계정을 통한 회원가입을 한 적이 있는 경우 : 가입한 단체가 있는지 확인하는 통신 코드 구현
+            networkManager.getUserInfo { [weak self] state in
+                guard let self else { return }
+                if KeychainHandler.shared.userGroup.isEmpty {
+                    /// 가입한 단체가 없는 경우 - 온보딩 화면에서 단체를 선택한 경험이 없는 경우
+                    rootViewController = onboardingViewController
+                } else {
+                    /// 가입한 단체가 있는 경우 - 온보딩 화면에서 단체를 선택한 경험이 있는 경우
+                    rootViewController = PINGLETabBarController
                 }
             }
+        }
+        /// 스플래쉬 화면이 시작
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
             let navigationController = UINavigationController(rootViewController: rootViewController)
             
             window.rootViewController = navigationController

--- a/PINGLE-iOS/PINGLE-iOS/Global/Components/PINGLETextFieldView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Components/PINGLETextFieldView.swift
@@ -26,7 +26,7 @@ final class PINGLETextFieldView: BaseView {
         self.searchTextField.attributedPlaceholder = NSAttributedString(
             string: explainLabel,
             attributes: [
-                .font: UIFont.bodyBodyMed14,
+                .font: UIFont.bodyBodyMed16,
                 .foregroundColor: UIColor.grayscaleG07
             ]
         )

--- a/PINGLE-iOS/PINGLE-iOS/Global/Literals/StringLiterals.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Literals/StringLiterals.swift
@@ -173,10 +173,9 @@ enum StringLiterals {
         
         enum Profile {
             enum ExplainTitle {
-                static let settingTitle = "설정"
+                static let settingTitle = "더보기"
                 static let organizationTitle = "나의 단체"
                 static let versionTitle = "버전"
-                static let versionInfo = "0.0.0"
                 static let logoutQuestionTitle = "정말로 로그아웃 하실건가요?"
                 static let deleteQuestionTitle = "정말로 탈퇴하실건가요?"
                 static let logoutExplanation = "Apple 계정을 로그아웃합니다"

--- a/PINGLE-iOS/PINGLE-iOS/Network/Base/HTTPHeaderFieldKey.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Base/HTTPHeaderFieldKey.swift
@@ -29,6 +29,7 @@ enum HTTPHeaderType {
     case hasToken
     case refreshToken
     case teamId
+    case deleteAppleId
 }
 
 @frozen
@@ -37,5 +38,4 @@ enum Authorization {
     case unauthorization
     case socialAuthorization
     case reAuthorization
-    case deleteAppleId
 }

--- a/PINGLE-iOS/PINGLE-iOS/Network/Base/PINGLERequestInterceptor.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Base/PINGLERequestInterceptor.swift
@@ -77,7 +77,7 @@ final class PINGLERequestInterceptor: RequestInterceptor {
                 self.logout()
             default:
                 completion(false)
-                /// 재발행에 실패하여 로그아웃 처리.
+                self.logout()
             }
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Network/Base/TargetType.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Base/TargetType.swift
@@ -49,6 +49,11 @@ extension TargetType {
                 HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
                 HTTPHeaderFieldKey.teamId.rawValue: "\(KeychainHandler.shared.userGroup[0].id)"
             ]
+        case .deleteAppleId:
+            return [
+                HTTPHeaderFieldKey.contentType.rawValue: HTTPHeaderFieldValue.json.rawValue,
+                HTTPHeaderFieldKey.deleteAppleId.rawValue: KeychainHandler.shared.authorizationCode
+            ]
         }
     }
 }
@@ -70,8 +75,6 @@ extension TargetType {
             urlRequest.setValue(KeychainHandler.shared.providerToken, forHTTPHeaderField: HTTPHeaderFieldKey.providerToken.rawValue)
         case .reAuthorization:
             urlRequest.setValue(KeychainHandler.shared.refreshToken, forHTTPHeaderField: HTTPHeaderFieldKey.authentication.rawValue)
-        case .deleteAppleId:
-            urlRequest.setValue(KeychainHandler.shared.authorizationCode, forHTTPHeaderField: HTTPHeaderFieldKey.deleteAppleId.rawValue)
         }
         
         switch headerType {
@@ -89,6 +92,9 @@ extension TargetType {
         case .teamId:
             urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
             urlRequest.setValue("\(KeychainHandler.shared.userGroup[0].id)", forHTTPHeaderField: HTTPHeaderFieldKey.teamId.rawValue)
+        case .deleteAppleId:
+            urlRequest.setValue(HTTPHeaderFieldValue.json.rawValue, forHTTPHeaderField: HTTPHeaderFieldKey.contentType.rawValue)
+            urlRequest.setValue(KeychainHandler.shared.authorizationCode, forHTTPHeaderField: HTTPHeaderFieldKey.deleteAppleId.rawValue)
         }
         
         switch parameters {

--- a/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/UserInfoResponseDTO.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Onboarding/Response/UserInfoResponseDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 struct UserInfoResponseDTO: Codable {
     let id: Int
     let name, email, provider: String
-    let groups: [UserGroup]
+    let groups: [UserGroup]?
 }
 
 struct UserGroup: Codable {

--- a/PINGLE-iOS/PINGLE-iOS/Network/Profile/Router/ProfileTarget.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Network/Profile/Router/ProfileTarget.swift
@@ -20,7 +20,7 @@ extension ProfileTarget: TargetType {
         case .logout:
             return .authorization
         case .deleteID:
-            return .deleteAppleId
+            return .authorization
         }
     }
     
@@ -29,7 +29,7 @@ extension ProfileTarget: TargetType {
         case .logout:
             return .hasToken
         case .deleteID:
-            return .hasToken
+            return .deleteAppleId
         }
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/OrganizationInfoView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/OrganizationInfoView.swift
@@ -71,18 +71,18 @@ final class OrganizationInfoView: BaseView {
                          meetingNumberLabel, memberNumberTitleLabel, memberNumberLabel)
         
         keywordLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(20.adjusted)
+            $0.top.equalToSuperview().inset(20)
             $0.leading.equalToSuperview().inset(23.adjusted)
         }
         
         organizationNameLabel.snp.makeConstraints {
-            $0.top.equalTo(keywordLabel.snp.bottom).offset(4.adjusted)
+            $0.top.equalTo(keywordLabel.snp.bottom).offset(4)
             $0.leading.trailing.equalToSuperview().inset(23.adjusted)
-            $0.height.equalTo(34.adjusted)
+            $0.height.equalTo(34)
         }
         
         meetingNumberTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(organizationNameLabel.snp.bottom).offset(10.adjusted)
+            $0.top.equalTo(organizationNameLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(23.adjusted)
         }
         
@@ -92,7 +92,7 @@ final class OrganizationInfoView: BaseView {
         }
         
         memberNumberTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(meetingNumberTitleLabel.snp.bottom).offset(4.adjusted)
+            $0.top.equalTo(meetingNumberTitleLabel.snp.bottom).offset(4)
             $0.leading.equalToSuperview().inset(23.adjusted)
         }
         

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/SearchOrganizationView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/View/SearchOrganizationView.swift
@@ -74,11 +74,11 @@ final class SearchOrganizationView: BaseView {
         searchView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(24.adjusted)
-            $0.height.equalTo(44.adjusted)
+            $0.height.equalTo(44)
         }
         
         searchTextField.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview().inset(10.adjusted)
+            $0.top.bottom.equalToSuperview().inset(10)
             $0.leading.equalToSuperview().inset(13.adjusted)
             $0.trailing.equalToSuperview().inset(54.adjusted)
         }
@@ -86,11 +86,11 @@ final class SearchOrganizationView: BaseView {
         searchButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(13.adjusted)
             $0.centerY.equalToSuperview()
-            $0.height.width.equalTo(24.adjusted)
+            $0.height.width.equalTo(24)
         }
         
         searchCollectionView.snp.makeConstraints {
-            $0.top.equalTo(self.searchView.snp.bottom).offset(21.adjusted)
+            $0.top.equalTo(self.searchView.snp.bottom).offset(21)
             $0.leading.trailing.equalToSuperview().inset(25.adjusted)
             $0.bottom.equalToSuperview()
         }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EnterInviteCodeViewController.swift
@@ -91,27 +91,27 @@ final class EnterInviteCodeViewController: BaseViewController {
         titleBackgroundView.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(113.adjusted)
+            $0.height.equalTo(113)
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(32.adjusted)
+            $0.top.equalToSuperview().inset(32)
             $0.leading.equalToSuperview().inset(26.adjusted)
         }
         
         organizationInfoView.snp.makeConstraints {
-            $0.top.equalTo(self.titleLabel.snp.bottom).offset(25.adjusted)
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(25)
             $0.leading.trailing.equalToSuperview().inset(24.adjusted)
-            $0.height.equalTo(157.adjusted)
+            $0.height.equalTo(157)
         }
         
         inviteCodeTextFieldView.snp.makeConstraints {
-            $0.top.equalTo(organizationInfoView.snp.bottom).offset(16.adjusted)
+            $0.top.equalTo(organizationInfoView.snp.bottom).offset(16)
             $0.centerX.equalToSuperview()
         }
         
         infoImageView.snp.makeConstraints {
-            $0.top.equalTo(inviteCodeTextFieldView.snp.bottom).offset(8.adjusted)
+            $0.top.equalTo(inviteCodeTextFieldView.snp.bottom).offset(8)
             $0.leading.equalTo(inviteCodeTextFieldView)
             $0.width.height.equalTo(10.adjusted)
         }
@@ -122,12 +122,12 @@ final class EnterInviteCodeViewController: BaseViewController {
         }
         
         bottomCTAButton.snp.makeConstraints {
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(40.adjusted)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(41.adjusted)
             $0.centerX.equalToSuperview()
         }
         
         warningToastView.snp.makeConstraints {
-            $0.bottom.equalTo(bottomCTAButton.snp.top).offset(-16.adjusted)
+            $0.bottom.equalTo(bottomCTAButton.snp.top).offset(-16)
             $0.centerX.equalToSuperview()
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
@@ -41,13 +41,14 @@ final class EntranceCompletedViewController: BaseViewController {
         
         self.titleLabel.do {
             $0.text = StringLiterals.Onboarding.ExplainTitle.entranceTitle
+            $0.setTextWithLineHeight(text: StringLiterals.Onboarding.ExplainTitle.entranceTitle, lineHeight: 45)
+            $0.textAlignment = .left
             $0.font = .titleTitleSemi32
             $0.textColor = .white
             $0.numberOfLines = 0
         }
         
         self.organizationNameLabel.do {
-            $0.text = "단체명"
             $0.font = .subtitleSubSemi16
             $0.textColor = .grayscaleG01
         }
@@ -74,12 +75,12 @@ final class EntranceCompletedViewController: BaseViewController {
                               welcomLabel, backgroundImageView, bottomCTAButton)
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(132.adjusted)
+            $0.top.equalToSuperview().inset(126)
             $0.leading.equalToSuperview().inset(24.adjusted)
         }
         
         organizationNameLabel.snp.makeConstraints {
-            $0.top.equalTo(self.titleLabel.snp.bottom).offset(16.adjusted)
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(24.adjusted)
         }
         
@@ -89,18 +90,18 @@ final class EntranceCompletedViewController: BaseViewController {
         }
         
         welcomLabel.snp.makeConstraints {
-            $0.top.equalTo(self.organizationNameLabel.snp.bottom).offset(4.adjusted)
+            $0.top.equalTo(self.organizationNameLabel.snp.bottom).offset(4)
             $0.leading.equalToSuperview().inset(24.adjusted)
         }
         
         backgroundImageView.snp.makeConstraints {
-            $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-16.adjusted)
+            $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-16)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(353.adjusted)
+            $0.height.equalTo(353)
         }
         
         bottomCTAButton.snp.makeConstraints {
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(40.adjusted)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(41)
             $0.centerX.equalToSuperview()
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/EntranceCompletedViewController.swift
@@ -67,6 +67,7 @@ final class EntranceCompletedViewController: BaseViewController {
         
         self.backgroundImageView.do {
             $0.image = ImageLiterals.OnBoarding.imgGraphic1
+            $0.contentMode = .scaleAspectFit
         }
     }
     
@@ -94,15 +95,24 @@ final class EntranceCompletedViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(24.adjusted)
         }
         
-        backgroundImageView.snp.makeConstraints {
-            $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-16)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(353)
-        }
-        
         bottomCTAButton.snp.makeConstraints {
             $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(41)
             $0.centerX.equalToSuperview()
+        }
+        
+        if UIScreen.main.bounds.height > 667 {
+            backgroundImageView.snp.makeConstraints {
+                $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-16)
+                $0.trailing.equalToSuperview()
+                $0.height.equalTo(447)
+                $0.width.equalTo(475)
+            }
+        } else {
+            backgroundImageView.snp.makeConstraints {
+                $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-16)
+                $0.leading.trailing.equalToSuperview()
+                $0.height.equalTo(353)
+            }
         }
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
@@ -143,7 +143,9 @@ final class LoginViewController: BaseViewController {
             switch response {
             case .success(let data):
                 guard let data = data.data else { return }
-                KeychainHandler.shared.userGroup = data.groups
+                if let groups = data.groups {
+                    KeychainHandler.shared.userGroup = groups
+                }
                 if KeychainHandler.shared.userGroup.isEmpty {
                     let onboardingViewController = OnboardingViewController()
                     self.navigationController?.pushViewController(onboardingViewController, animated: true)

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/LoginViewController.swift
@@ -74,29 +74,29 @@ final class LoginViewController: BaseViewController {
                               adviceLabel, authorizationButton)
         
         logoImageView.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(63.adjusted)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(63)
             $0.leading.equalToSuperview().inset(32.adjusted)
-            $0.height.equalTo(73.adjusted)
-            $0.width.equalTo(73.adjusted)
+            $0.height.equalTo(73)
+            $0.width.equalTo(73)
         }
         
         loginTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(self.logoImageView.snp.bottom).offset(12.adjusted)
+            $0.top.equalTo(self.logoImageView.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(32.adjusted)
         }
         
         introduceLabel.snp.makeConstraints {
-            $0.top.equalTo(self.loginTitleLabel.snp.bottom).offset(12.adjusted)
+            $0.top.equalTo(self.loginTitleLabel.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(32.adjusted)
         }
         
         adviceLabel.snp.makeConstraints {
-            $0.top.equalTo(self.introduceLabel.snp.bottom).offset(3.adjusted)
+            $0.top.equalTo(self.introduceLabel.snp.bottom).offset(3)
             $0.leading.equalToSuperview().inset(32.adjusted)
         }
         
         authorizationButton.snp.makeConstraints {
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(69.adjusted)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(69)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(58)
             $0.width.equalTo(UIScreen.main.bounds.size.width - 32)

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/OnboardingViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/OnboardingViewController.swift
@@ -73,22 +73,22 @@ final class OnboardingViewController: BaseViewController {
         self.view.addSubviews(titleLabel, existingOrganizationButton, makeOrganizationButton)
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(105.adjusted)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(105)
             $0.leading.equalToSuperview().inset(26.adjusted)
         }
         
         existingOrganizationButton.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(34.adjusted)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(34)
             $0.leading.equalToSuperview().inset(24.adjusted)
-            $0.height.equalTo(224.adjusted)
-            $0.width.equalTo((UIScreen.main.bounds.size.width - 57) / 2)
+            $0.height.equalTo(224)
+            $0.width.equalTo((UIScreen.main.bounds.size.width - 57.adjusted) / 2)
         }
         
         makeOrganizationButton.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(34.adjusted)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(34)
             $0.trailing.equalToSuperview().inset(24.adjusted)
-            $0.height.equalTo(224.adjusted)
-            $0.width.equalTo((UIScreen.main.bounds.size.width - 57) / 2)
+            $0.height.equalTo(224)
+            $0.width.equalTo((UIScreen.main.bounds.size.width - 57.adjusted) / 2)
         }
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
@@ -75,30 +75,30 @@ final class SearchOrganizationViewController: BaseViewController {
         self.view.addSubviews(titleLabel, searchOrganizationView, bottomRequestLabel, makeOrganizationButton, bottomCTAButton)
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(32.adjusted)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(32)
             $0.leading.equalToSuperview().inset(26.adjusted)
         }
         
         searchOrganizationView.snp.makeConstraints {
-            $0.top.equalTo(self.titleLabel.snp.bottom).offset(24.adjusted)
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(154.adjusted)
+            $0.bottom.equalTo(self.bottomRequestLabel.snp.top).offset(-18)
         }
         
         bottomRequestLabel.snp.makeConstraints {
-            $0.top.equalTo(self.searchOrganizationView.snp.bottom).offset(18.adjusted)
+            $0.bottom.equalTo(self.bottomCTAButton.snp.top).offset(-20)
             $0.leading.equalToSuperview().inset(77.adjusted)
         }
         
         makeOrganizationButton.snp.makeConstraints {
             $0.centerY.equalTo(self.bottomRequestLabel)
             $0.leading.equalTo(self.bottomRequestLabel.snp.trailing).offset(4.adjusted)
-            $0.height.equalTo(17.adjusted)
+            $0.height.equalTo(17)
             $0.width.equalTo(121.adjusted)
         }
         
         bottomCTAButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(41.adjusted)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(41)
             $0.centerX.equalToSuperview()
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Onboarding/ViewController/SearchOrganizationViewController.swift
@@ -146,19 +146,14 @@ final class SearchOrganizationViewController: BaseViewController {
     }
     
     @objc func searchButtonTapped() {
-        /// 검색 결과가 없는 경우 "검색 결과가 없어요" 라벨이 나옵니다. 검색결과가 있는 경우 "검색 결과가 없어요" 라벨이 사라집니다.
+        /// 검색하는 내용이 없을 경우 아무런 통신도 하지 않고 이전 상태를 유지합니다.
         if let searchText = searchOrganizationView.searchTextField.text {
-            if searchText.isEmpty {
-                searchOrganizationResponseDTO = []
-                searchOrganizationView.searchCollectionView.reloadData()
-                searchOrganizationView.noResultLabel.isHidden = false
-            } else {
+            if !searchText.isEmpty {
                 searchOrganization(data: SearchOrganizationRequestQueryDTO(name: searchText))
+                selectedCellIndex = nil
+                bottomCTAButton.disabledButton()
             }
         }
-        /// 선택된 행 해제한 뒤, 다음으로 버튼 비활성화
-        selectedCellIndex = nil
-        bottomCTAButton.disabledButton()
         self.view.endEditing(true)
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/Component/OrganizationButton.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/Component/OrganizationButton.swift
@@ -55,23 +55,23 @@ class OrganizationButton: UIButton {
         
         self.snp.makeConstraints {
             $0.width.equalTo(343.adjustedWidth)
-            $0.height.equalTo(74.adjusted)
+            $0.height.equalTo(74)
         }
         
         organizationTitleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14.adjusted)
+            $0.top.equalToSuperview().inset(14)
             $0.leading.equalToSuperview().inset(21.adjusted)
         }
         
         organizationNameLabel.snp.makeConstraints {
-            $0.top.equalTo(self.organizationTitleLabel.snp.bottom).offset(4.adjusted)
+            $0.top.equalTo(self.organizationTitleLabel.snp.bottom).offset(4)
             $0.leading.equalToSuperview().inset(21.adjusted)
         }
         
         arrowRightImageView.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16.adjusted)
             $0.centerY.equalToSuperview()
-            $0.height.equalTo(22.adjusted)
+            $0.height.equalTo(22)
             $0.width.equalTo(24.adjusted)
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/Component/SettingSelectButton.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/Component/SettingSelectButton.swift
@@ -46,8 +46,8 @@ class SettingSelectButton: UIButton {
         self.addSubviews(settingTitleLabel)
         
         self.snp.makeConstraints {
-            $0.width.equalTo(UIScreen.main.bounds.size.width - 32)
-            $0.height.equalTo(50.adjusted)
+            $0.width.equalTo(UIScreen.main.bounds.size.width - 32.adjusted)
+            $0.height.equalTo(50)
         }
         
         settingTitleLabel.snp.makeConstraints {

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/View/AccountPopUpView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/View/AccountPopUpView.swift
@@ -53,11 +53,10 @@ final class AccountPopUpView: BaseView {
         }
         
         self.changeStateButton.do {
-            //            $changeStateButton.setTitle(StringLiterals.Profile.ButtonTitle.logoutTitle, for: .normal)
             $0.titleLabel?.font = .captionCapSemi12
             $0.setTitleColor(.grayscaleG01, for: .normal)
             $0.titleLabel?.textAlignment = .center
-            $0.layer.addBorder([.bottom], color: .grayscaleG01, width: 1.0, frameHeight: 17.0.adjusted, framgeWidth: 42.0.adjusted)
+            $0.layer.addBorder([.bottom], color: .grayscaleG01, width: 1.0, frameHeight: 17.0, framgeWidth: 42.0.adjusted)
         }
     }
     
@@ -66,31 +65,31 @@ final class AccountPopUpView: BaseView {
                          changeStateButton)
         
         self.snp.makeConstraints {
-            $0.width.equalTo(UIScreen.main.bounds.size.width - 48)
-            $0.height.equalTo(232.adjusted)
+            $0.width.equalTo(UIScreen.main.bounds.size.width - 48.adjusted)
+            $0.height.equalTo(232)
         }
         
         questionLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(46.adjusted)
+            $0.top.equalToSuperview().inset(46)
             $0.centerX.equalToSuperview()
         }
         
         explanationLabel.snp.makeConstraints {
-            $0.top.equalTo(self.questionLabel.snp.bottom).offset(4.adjusted)
+            $0.top.equalTo(self.questionLabel.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
         }
         
         backButton.snp.makeConstraints {
-            $0.top.equalTo(self.explanationLabel.snp.bottom).offset(35.adjusted)
+            $0.top.equalTo(self.explanationLabel.snp.bottom).offset(35)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(185.adjustedWidth)
-            $0.height.equalTo(44.adjusted)
+            $0.height.equalTo(44)
         }
         
         changeStateButton.snp.makeConstraints {
-            $0.top.equalTo(self.backButton.snp.bottom).offset(12.adjusted)
+            $0.top.equalTo(self.backButton.snp.bottom).offset(12)
             $0.centerX.equalToSuperview()
-            $0.height.equalTo(17.adjusted)
+            $0.height.equalTo(17)
             $0.width.equalTo(42.adjusted)
         }
     }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/View/SettingSelectView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/View/SettingSelectView.swift
@@ -52,7 +52,7 @@ final class SettingSelectView: BaseView {
             $0.text = StringLiterals.Profile.ButtonTitle.deleteTitle
             $0.font = .captionCapSemi12
             $0.textColor = .grayscaleG06
-            $0.layer.addBorder([.bottom], color: .grayscaleG06, width: 1.0, frameHeight: 17.0.adjusted, framgeWidth: 42.0.adjusted)
+            $0.layer.addBorder([.bottom], color: .grayscaleG06, width: 1.0, frameHeight: 17.0, framgeWidth: 42.0.adjusted)
         }
     }
     
@@ -64,23 +64,23 @@ final class SettingSelectView: BaseView {
         self.deleteButton.addSubview(deleteLabel)
         
         self.snp.makeConstraints {
-            $0.width.equalTo(UIScreen.main.bounds.size.width - 32)
-            $0.height.equalTo(328.adjusted)
+            $0.width.equalTo(UIScreen.main.bounds.size.width - 32.adjusted)
+            $0.height.equalTo(328)
         }
         
         contactButton.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(50.adjusted)
+            $0.height.equalTo(50)
         }
         
         noticeButton.snp.makeConstraints {
             $0.top.equalTo(self.contactButton.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(50.adjusted)
+            $0.height.equalTo(50)
         }
         
         versionTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(self.noticeButton.snp.bottom).offset(14.adjusted)
+            $0.top.equalTo(self.noticeButton.snp.bottom).offset(14)
             $0.leading.equalToSuperview().inset(4.adjusted)
         }
         
@@ -90,19 +90,19 @@ final class SettingSelectView: BaseView {
         }
         
         horizontalLineView.snp.makeConstraints {
-            $0.top.equalTo(self.versionTitleLabel.snp.bottom).offset(14.adjusted)
+            $0.top.equalTo(self.versionTitleLabel.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1)
         }
         
         logoutButton.snp.makeConstraints {
-            $0.top.equalTo(self.versionTitleLabel.snp.bottom).offset(15.adjusted)
+            $0.top.equalTo(self.versionTitleLabel.snp.bottom).offset(15)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(50.adjusted)
+            $0.height.equalTo(50)
         }
         
         deleteButton.snp.makeConstraints {
-            $0.top.equalTo(self.logoutButton.snp.bottom).offset(8.adjusted)
+            $0.top.equalTo(self.logoutButton.snp.bottom).offset(8)
             $0.trailing.equalToSuperview()
             $0.width.equalTo(50.adjustedWidth)
             $0.height.equalTo(45)

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/MyOrganizationViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/MyOrganizationViewController.swift
@@ -1,0 +1,77 @@
+//
+//  MyOrganizationViewController.swift
+//  PINGLE-iOS
+//
+//  Created by 강민수 on 1/14/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MyOrganizationViewController: BaseViewController {
+    
+    // MARK: - Variables
+    // MARK: Component
+    private let fixView = FixView()
+    private let backButton = UIButton()
+    
+    // MARK: - Function
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setAddTarget()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setNavigationBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+    }
+    
+    private func setNavigationBar() {
+        self.navigationController?.navigationBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
+    }
+    
+    // MARK: Style Helpers
+    override func setStyle() {
+        self.navigationController?.navigationBar.isHidden = true
+        self.view.backgroundColor = .grayscaleG11
+        
+        backButton.do {
+            $0.setImage(ImageLiterals.Icon.imgArrowLeft, for: .normal)
+        }
+    }
+    
+    private func setAddTarget() {
+        backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+    }
+    
+    // MARK: Objc Function
+    @objc func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    // MARK: Style Helpers
+    override func setLayout() {
+        
+        self.view.addSubviews(backButton,
+                              fixView)
+        
+        backButton.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(16.adjusted)
+            $0.leading.equalToSuperview().inset(18)
+        }
+        
+        fixView.snp.makeConstraints {
+            $0.top.equalTo(backButton.snp.bottom).offset(77.adjustedHeight)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}
+

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/SettingViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/SettingViewController.swift
@@ -75,22 +75,22 @@ final class SettingViewController: BaseViewController {
         }
         
         settingTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(15.adjusted)
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(15)
             $0.leading.equalTo(self.view).offset(16.adjusted)
         }
         
         userNameLabel.snp.makeConstraints {
-            $0.top.equalTo(self.settingTitleLabel.snp.bottom).offset(36.adjusted)
+            $0.top.equalTo(self.settingTitleLabel.snp.bottom).offset(36)
             $0.leading.equalTo(self.view).offset(16.adjusted)
         }
         
         organizationButton.snp.makeConstraints {
-            $0.top.equalTo(self.userNameLabel.snp.bottom).offset(20.adjusted)
+            $0.top.equalTo(self.userNameLabel.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
         }
         
         settingSelectView.snp.makeConstraints {
-            $0.top.equalTo(self.organizationButton.snp.bottom).offset(40.adjusted)
+            $0.top.equalTo(self.organizationButton.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
         }
         

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/SettingViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/SettingViewController.swift
@@ -127,6 +127,8 @@ final class SettingViewController: BaseViewController {
     
     // MARK: Objc Function
     @objc func organizationButtonTapped() {
+        let myOrganizationViewController = MyOrganizationViewController()
+        self.navigationController?.pushViewController(myOrganizationViewController, animated: true)
     }
     
     @objc func contactButtonTapped() {

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Splash/SplashViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Splash/SplashViewController.swift
@@ -25,8 +25,7 @@ final class SplashViewController: BaseViewController {
         view.addSubview(PINGLELogoImageView)
         
         PINGLELogoImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(212)
-            $0.centerX.equalToSuperview()
+            $0.centerX.centerY.equalToSuperview()
             $0.width.equalTo(153)
             $0.height.equalTo(191)
         }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Splash/SplashViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Splash/SplashViewController.swift
@@ -25,7 +25,7 @@ final class SplashViewController: BaseViewController {
         view.addSubview(PINGLELogoImageView)
         
         PINGLELogoImageView.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
+            $0.center.equalToSuperview()
             $0.width.equalTo(153)
             $0.height.equalTo(191)
         }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- top, bottom Layout과 height 관련하여 adjusted를 제거했습니다.
- 신델리게이트에서 통신하는 함수를 asyncAfter 1.5초가 기다리기 이전에 구현함으로써 통신이 느리게 되었을 경우에 기본 VC로 이동하는 것을 방지했습니다. 만약 1.5초 이전에 통신이 안되었을 경우에는 기본적으로 로그인 화면으로 이동시켜 로그인 시키도록 했습니다.
https://github.com/TeamPINGLE/PINGLE-iOS/blob/9694883baf810d5f0fe591e5d82bd711800993a5/PINGLE-iOS/PINGLE-iOS/Application/SceneDelegate.swift#L14-L54

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- 루트 뷰 분기처리 과정은 이후 더 딥하게 공부해서 효율적으로 작성하도록 노력하겠습니다.


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- StringLiterals


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |  
| :-------------: |  
|  ![RPReplay_Final1705248297](https://github.com/TeamPINGLE/PINGLE-iOS/assets/62370742/3b459337-8f37-4244-a3a6-6f7e11d2a8d7) | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #107 
