### PR TITLE
Fix [#126] 홈 지도 scroll move 수정

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeMapViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeMapViewController.swift
@@ -181,7 +181,7 @@ extension HomeMapViewController: UICollectionViewDataSource {
                 if result {
                     print("참여하기 버튼 탭")
                     cell.mapDetailView.isParticipating = true
-                    self.bindDetailViewData(id: self.markerId, category: self.markerCategory)
+                    self.bindDetailViewData(id: self.markerId, category: self.markerCategory) {}
                 }
             }
         }
@@ -192,7 +192,7 @@ extension HomeMapViewController: UICollectionViewDataSource {
                 if result {
                     print("취소하기 버튼 탭")
                     cell.mapDetailView.isParticipating = false
-                    self.bindDetailViewData(id: self.markerId, category: self.markerCategory)
+                    self.bindDetailViewData(id: self.markerId, category: self.markerCategory) {}
                 }
             }
         }
@@ -311,7 +311,13 @@ extension HomeMapViewController {
             marker.touchHandler = { ( _: NMFOverlay) -> Bool in
                 print("오버레이 터치됨")
                 let category = self.markerCategory.isEmpty ? "" : marker.meetingString
-                self.bindDetailViewData(id: marker.id, category: category)
+                self.bindDetailViewData(id: marker.id, category: category) {
+                    /// 맨 처음 인덱스로 돌아오도록 스크롤
+                    if !self.homePinDetailList.isEmpty {
+                        let indexPath = IndexPath(item: 0, section: 0)
+                        self.mapsView.homeDetailCollectionView.scrollToItem(at: indexPath, at: .left, animated: false)
+                    }
+                }
                 self.mapsView.currentLocationButton.isHidden = true
                 self.mapsView.listButton.isHidden = true
                 self.markerTapped(marker: marker)
@@ -321,20 +327,15 @@ extension HomeMapViewController {
         }
     }
     
-    func bindDetailViewData(id: Int, category: String?) {
+    func bindDetailViewData(id: Int, category: String?, completion: @escaping () -> Void) {
         // 추후 바뀐 그룹 받아오는 로직 작성 예정
         self.pinDetail(pinId: id, category: category) { [weak self] result in
             guard let self else { return }
             if result {
                 self.mapsView.homeDetailCollectionView.reloadData()
                 self.mapsView.homeDetailCollectionView.isHidden = false
-
-                /// 맨 처음 인덱스로 돌아오도록 스크롤
-                if !self.homePinDetailList.isEmpty {
-                    let indexPath = IndexPath(item: 0, section: 0)
-                    self.mapsView.homeDetailCollectionView.scrollToItem(at: indexPath, at: .left, animated: false)
-                }
             }
+            completion()
         }
     }
     


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 참여 / 취소 할 때는 collectionView scroll이 안넘어가도록 했습니다!
- 데이터 바뀌기 이전에 indexPath 0으로 이동시키는 이슈가 있어서 다 받아오면 할 수 있도록 수정했습니다.
- 이슈에 넣었던 바로 로드 안되는 건 잘 되어서 따로 해결하지 않았습니다..

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- escaping 클로저를 너무 많이 만들어둔 것 같아서.. 요 부분을 중점적으로 봐주세요!


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- x


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   12pro   |   
| :-------------: | 
|     ![ezgif-7-caef359632](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/151f8dbb-b5fa-4e98-9342-8e37e844f53f)      |  


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #126 
