### PR TITLE
Fix [#223] 최종 오류 수정 (검색화면 진입 후 돌아왔을때 홈화면 search버튼 터치 안되는 이슈 해결)

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS/Presentation/TabBar/PINGLETabBarController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/TabBar/PINGLETabBarController.swift
@@ -96,7 +96,7 @@ final class PINGLETabBarController: UITabBarController {
     @objc func goToAddPingle() {
         let makeMeetingGuideViewController = MakeMeetingGuideViewController()
         let navigationController = UINavigationController(rootViewController: makeMeetingGuideViewController)
-        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.modalPresentationStyle = .overFullScreen
         self.present(navigationController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
-x

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
-> fullScreen과 overFullScreen의 차이로 인한 오류였습니다  ! 
이 부분 앱잼내에도 알았다면 , 죽지않는 네비바를 겪지 않아도 되었겠네요..!
 https://onelife2live.tistory.com/34


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- x


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

x


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #223 
