### PR TITLE
Fix [#218] 3차 스프린트 추가 오류 사항 수정 (단체 변경 시 홈 화면 리셋)

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS/Global/Extensions/NotificationName+.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Extensions/NotificationName+.swift
@@ -11,4 +11,5 @@ extension Notification.Name {
     static let updatePinAndList = Notification.Name(rawValue: "updatePinAndList")
     static let updateRanking = Notification.Name(rawValue: "updateRanking")
     static let clearTextField = Notification.Name(rawValue: "clearTextField")
+    static let changeGroupHome = Notification.Name(rawValue: "changeGroupHome")
 }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -341,6 +341,7 @@ final class HomeViewController: BaseViewController {
             navigationController?.popToRootViewController(animated: true)
         }
         isHomeMap = true
+        homeListViewController.category = ""
         resetChipSelected()
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -117,6 +117,12 @@ final class HomeViewController: BaseViewController {
             name: .updatePinAndList, object: nil
         )
         
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(changeGroupHome(_:)),
+            name: .changeGroupHome, object: nil
+        )
+        
         if isSearchResult {
             NotificationCenter.default.addObserver(
                 self,
@@ -328,6 +334,14 @@ final class HomeViewController: BaseViewController {
             homeMapViewController.hideSelectedPin()
             homeListViewController.reloadList()
         }
+    }
+    
+    @objc func changeGroupHome(_ notification: Notification) {
+        if isSearchResult {
+            navigationController?.popToRootViewController(animated: true)
+        }
+        isHomeMap = true
+        resetChipSelected()
     }
     
     @objc func keyboardWillShow() {

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/MyOrganizationViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Profile/ViewController/MyOrganizationViewController.swift
@@ -294,7 +294,7 @@ final class MyOrganizationViewController: BaseViewController {
             userInfo: nil)
       
         NotificationCenter.default.post(
-            name: .updatePinAndList,
+            name: .changeGroupHome,
             object: nil,
             userInfo: nil)
     }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 단체 변경 후 홈 화면의 카테고리와 검색 결과 등 리셋이 되지 않는 문제에 대한 해결을 했습니다.
- 홈 화면에 검색 결과 화면이 보여지고 있다면 rootViewController로 돌아오도록 했습니다.
- 지도와 리스트의 카테고리 핀을 리셋 해주었습니다.

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- 다른 경우에서의 충돌은 없을지 확인해주세요!


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- MyOrganizationViewController, Notification.Name+ 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [ ] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

| 검색 이후 단체 변경 시 홈 화면으로 돌아옴  |   카테고리 선택 후 단체 변경 시 다시 리셋 됨      | 
| :-------------: |  :-------------: |
|  ![Simulator Screen Recording - iPhone 15 Pro - 2024-03-13 at 14 35 31](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/cd3c2d1c-acf9-47a0-9c17-4a99c8233151)   | ![Simulator Screen Recording - iPhone 15 Pro - 2024-03-13 at 14 35 44](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/6d19bb57-f48c-4ce4-b97b-3a8c18cf36c8)    | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #218 
