### PR TITLE
Fix [#230] 3차 스프린트 - 디자인 QA 수정 사항 반영

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS/Global/Extensions/UIView+.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Extensions/UIView+.swift
@@ -16,7 +16,7 @@ extension UIView {
     }
     
     func makeShadow (radius: CGFloat, offset: CGSize, opacity: Float) {
-        layer.shadowColor = UIColor.darkGray.cgColor
+        layer.shadowColor = UIColor.black.cgColor
         layer.shadowOffset = offset
         layer.shadowRadius = radius
         layer.shadowOpacity = opacity

--- a/PINGLE-iOS/PINGLE-iOS/Global/Resources/Assets.xcassets/icMyPingleArrow.imageset/Contents.json
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Resources/Assets.xcassets/icMyPingleArrow.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "icMyPingleArrow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/PINGLE-iOS/PINGLE-iOS/Global/Resources/Assets.xcassets/icMyPingleArrow.imageset/icMyPingleArrow.svg
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Resources/Assets.xcassets/icMyPingleArrow.imageset/icMyPingleArrow.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="18" viewBox="0 0 6 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 13.5L5 9L1 4.5" stroke="#CAD1D9" stroke-width="1.58333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/View/HomeMapView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/View/HomeMapView.swift
@@ -80,11 +80,6 @@ final class HomeMapView: BaseView {
                 UIImage(resource: .icMapHere),
                 for: .normal
             )
-            $0.makeShadow(
-                radius: 5,
-                offset: CGSize(width: 0, height: 0),
-                opacity: 0.25
-            )
             $0.makeCornerRound(radius: 25.adjusted)
         }
         
@@ -100,11 +95,6 @@ final class HomeMapView: BaseView {
             $0.setImage(
                 UIImage(resource: .icMapList),
                 for: .normal
-            )
-            $0.makeShadow(
-                radius: 5,
-                offset: CGSize(width: 0, height: 0),
-                opacity: 0.25
             )
             $0.makeCornerRound(radius: 25.adjusted)
         }

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeListViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeListViewController.swift
@@ -131,11 +131,6 @@ final class HomeListViewController: BaseViewController {
                 UIImage(resource: .icMapMap),
                 for: .normal
             )
-            $0.makeShadow(
-                radius: 5,
-                offset: CGSize(width: 0, height: 0),
-                opacity: 0.25
-            )
             $0.makeCornerRound(radius: 25.adjusted)
         }
         

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -50,7 +50,6 @@ final class HomeViewController: BaseViewController {
         super.viewDidLoad()
         setResult()
         setAddTarget()
-        setNavigation()
         setTabBar()
     }
     
@@ -58,6 +57,7 @@ final class HomeViewController: BaseViewController {
         super.viewWillAppear(animated)
         setTabBar()
         setGroupName()
+        setNavigation()
     }
     
     private func setGroupName() {
@@ -173,7 +173,7 @@ final class HomeViewController: BaseViewController {
         
         chipStackView.do {
             $0.axis = .horizontal
-            $0.spacing = 4.adjustedWidth
+            $0.spacing = -4
         }
     }
     

--- a/PINGLE-iOS/PINGLE-iOS/Presentation/MyPingle/View/MyPINGLECardView.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Presentation/MyPingle/View/MyPINGLECardView.swift
@@ -153,7 +153,7 @@ final class MyPINGLECardView: BaseView {
         }
         
         memberArrow.do {
-            $0.image = UIImage(resource: .icArrowRight)
+            $0.image = UIImage(resource: .icMyPingleArrow)
             $0.isUserInteractionEnabled = false
         }
         
@@ -285,7 +285,7 @@ final class MyPINGLECardView: BaseView {
         
         memberArrow.snp.makeConstraints {
             $0.centerY.trailing.equalToSuperview()
-            $0.leading.equalTo(memberLabel.snp.trailing).offset(4.adjustedWidth)
+            $0.leading.equalTo(memberLabel.snp.trailing).offset(4)
         }
         
         myPingleImageView.snp.makeConstraints {


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 칩 사이 간격을 줄였습니다. 섀도우가 생긴 이슈로 버튼의 크기가 피그마 이미지와 달랐습니다.
- 마이핑글 arrow를 변경하여 간격을 좁혔습니다.

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- x


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- x


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

| 기종 |   홈 화면 칩   |   마이핑글 인원수 간격   | 
| :-------------: |  :-------------: |  :-------------: |
| se3   |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-15 at 05 01 41](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/d66b7177-eeb2-4b80-915f-638fdab0e8ca)  |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-15 at 05 02 01](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/a1a1755a-b877-40db-baf5-7f4cae9fee02) | 
|  12pro  |   ![IMG_7564](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/66fbf79d-11de-4b3a-baff-9600914d828e)    |   ![IMG_7565](https://github.com/TeamPINGLE/PINGLE-iOS/assets/109775321/f18d276b-1747-4fce-88f0-991e0c25b62e)  | 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #230 