### PR TITLE
Fix [#232] iOS 16.4 미만 버전 UILabel 수정

### DIFF
--- a/PINGLE-iOS/PINGLE-iOS/Global/Extensions/UILabel+.swift
+++ b/PINGLE-iOS/PINGLE-iOS/Global/Extensions/UILabel+.swift
@@ -121,10 +121,19 @@ extension UILabel {
             style.maximumLineHeight = lineHeight
             style.minimumLineHeight = lineHeight
             
-            let attributes: [NSAttributedString.Key: Any] = [
-                .paragraphStyle: style,
-                .baselineOffset: (lineHeight - font.lineHeight) / 2
-            ]
+            var attributes: [NSAttributedString.Key: Any] = [:]
+            if ProcessInfo.processInfo.isOperatingSystemAtLeast(
+                OperatingSystemVersion(majorVersion: 16, minorVersion: 4, patchVersion: 0)) {
+                attributes = [
+                    .paragraphStyle: style,
+                    .baselineOffset: (lineHeight - font.lineHeight) / 2
+                ]
+            } else {
+                attributes = [
+                    .paragraphStyle: style,
+                    .baselineOffset: (lineHeight - font.lineHeight) / 4
+                ]
+            }
             
             let attrString = NSAttributedString(string: text,
                                                 attributes: attributes)


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- ProcessInfo.processInfo.isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 16, minorVersion: 4, patchVersion: 0))코드를 이용해서 16.4.0 버전 이상과 아래 버전으로 나누어 작업했습니다.

https://sujinnaljin.medium.com/swift-label%EC%9D%98-line-height-%EC%84%A4%EC%A0%95-%EB%B0%8F-%EA%B0%80%EC%9A%B4%EB%8D%B0-%EC%A0%95%EB%A0%AC-962f7c6e7512

해당 블로그를 참조해주세요.

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- setTextWithLineHeight함수를 사용하는 부분에서 이러한 이슈가 발생했었습니다. 해당 함수 수정하는 방식에 대해서 어떻게 생각하는지 궁금합니다.


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- UILabel+

추가적으로 용량이 부족한 여러분들께 죄송한 말씀이지만 iOS 15버전 혹은 iOS 16버전으로 작동 해 봐야하기 때문에 다운받아 이후 작업할 때 확인하며 작업해야할 것 같습니다.


## ❇️ PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

|   뷰   |  
| :-------------: |  
| <img width="363" alt="스크린샷 2024-03-19 오후 5 12 07" src="https://github.com/TeamPINGLE/PINGLE-iOS/assets/62370742/67ab792c-7052-4d8a-8b1b-9948f97d9769">| 


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #232 
